### PR TITLE
Use SBUnlockActionContext to launch URL from lock screen instead

### DIFF
--- a/FSLaunchURL.x
+++ b/FSLaunchURL.x
@@ -56,6 +56,7 @@ void FSLaunchURL(NSURL *url)
 			[controller setCustomUnlockActionContext:context];
 			[controller setPasscodeLockVisible:YES animated:YES completion:nil];
 			[context release];
+			return;
 		}
 	}
 	FSLaunchURLDirect(url);


### PR DESCRIPTION
This will make allow it to animate to the passcode and launch more smoothly. It won't dismiss Control Center if it's open but it's probably better to do that in the Control Center tweak instead.
