### PR TITLE
LTE toggle settings (instead of using always MAX connection)

### DIFF
--- a/Switches/3G/Switch.x
+++ b/Switches/3G/Switch.x
@@ -20,7 +20,7 @@ void CTTelephonyCenterRemoveObserver(CFNotificationCenterRef center, const void 
 
 @interface DataSpeedSwitch : NSObject <FSSwitchDataSource> {
 @private
-  NSBundle *_bundle;
+	NSBundle *_bundle;
 }
 @property (nonatomic, readonly) NSBundle *bundle;
 @end
@@ -38,117 +38,117 @@ static void FSDataStatusChanged(void);
 
 - (id)init
 {
-  [self release];
-  return nil;
+	[self release];
+	return nil;
 }
 
 - (id)initWithBundle:(NSBundle *)bundle
 {
-  if ((self = [super init])) {
-    _bundle = [bundle retain];
-  }
+	if ((self = [super init])) {
+		_bundle = [bundle retain];
+	}
 
-  return self;
+	return self;
 }
 
 - (void)dealloc
 {
-  [_bundle release];
-  [super dealloc];
+	[_bundle release];
+	[super dealloc];
 }
 
 @synthesize bundle = _bundle;
 
 - (NSBundle *)bundleForSwitchIdentifier:(NSString *)switchIdentifier
 {
-  return _bundle;
+	return _bundle;
 }
 
 - (FSSwitchState)stateForSwitchIdentifier:(NSString *)switchIdentifier
 {
-  NSArray *supportedDataRates = [(NSArray *)CTRegistrationCopySupportedDataRates() autorelease];
-  NSUInteger desiredRateIndex = [supportedDataRates indexOfObject:(id)[self chosenDataRate:YES]];
-  if (desiredRateIndex == NSNotFound)
-    return FSSwitchStateOff;
-  NSUInteger currentRateIndex = [supportedDataRates indexOfObject:(id)CTRegistrationGetCurrentMaxAllowedDataRate()];
-  if (currentRateIndex == NSNotFound)
-    return FSSwitchStateOff;
-  return currentRateIndex >= desiredRateIndex;
+	NSArray *supportedDataRates = [(NSArray *)CTRegistrationCopySupportedDataRates() autorelease];
+	NSUInteger desiredRateIndex = [supportedDataRates indexOfObject:(id)[self chosenDataRate:YES]];
+	if (desiredRateIndex == NSNotFound)
+		return FSSwitchStateOff;
+	NSUInteger currentRateIndex = [supportedDataRates indexOfObject:(id)CTRegistrationGetCurrentMaxAllowedDataRate()];
+	if (currentRateIndex == NSNotFound)
+		return FSSwitchStateOff;
+	return currentRateIndex >= desiredRateIndex;
 }
 
 - (void)applyState:(FSSwitchState)newState forSwitchIdentifier:(NSString *)switchIdentifier
 {
-  if (newState == FSSwitchStateIndeterminate)
-    return;
-  NSArray *supportedDataRates = [(NSArray *)CTRegistrationCopySupportedDataRates() autorelease];
-  NSUInteger desiredRateIndex = [supportedDataRates indexOfObject:(id)[self chosenDataRate:YES]];
-  if (desiredRateIndex == NSNotFound)
-    return;
-  NSUInteger currentRateIndex = [supportedDataRates indexOfObject:(id)CTRegistrationGetCurrentMaxAllowedDataRate()];
-  if (currentRateIndex == NSNotFound)
-    return;
-  if (newState) {
-    if (currentRateIndex < desiredRateIndex)
-      CTRegistrationSetMaxAllowedDataRate([self chosenDataRate:YES]);
-  } else {
-    if ((currentRateIndex >= desiredRateIndex) && desiredRateIndex)
-      CTRegistrationSetMaxAllowedDataRate([self chosenDataRate:NO]);
-  }
+	if (newState == FSSwitchStateIndeterminate)
+		return;
+	NSArray *supportedDataRates = [(NSArray *)CTRegistrationCopySupportedDataRates() autorelease];
+	NSUInteger desiredRateIndex = [supportedDataRates indexOfObject:(id)[self chosenDataRate:YES]];
+	if (desiredRateIndex == NSNotFound)
+		return;
+	NSUInteger currentRateIndex = [supportedDataRates indexOfObject:(id)CTRegistrationGetCurrentMaxAllowedDataRate()];
+	if (currentRateIndex == NSNotFound)
+		return;
+	if (newState) {
+		if (currentRateIndex < desiredRateIndex)
+			CTRegistrationSetMaxAllowedDataRate([self chosenDataRate:YES]);
+	} else {
+		if ((currentRateIndex >= desiredRateIndex) && desiredRateIndex)
+			CTRegistrationSetMaxAllowedDataRate([self chosenDataRate:NO]);
+	}
 }
 
 - (void)applyAlternateActionForSwitchIdentifier:(NSString *)switchIdentifier
 {
-  NSURL *url = [NSURL URLWithString:(kCFCoreFoundationVersionNumber > 700.0f ? @"prefs:root=General&path=MOBILE_DATA_SETTINGS_ID" : @"prefs:root=General&path=Network")];
-  [[FSSwitchPanel sharedPanel] openURLAsAlternateAction:url];
+	NSURL *url = [NSURL URLWithString:(kCFCoreFoundationVersionNumber > 700.0f ? @"prefs:root=General&path=MOBILE_DATA_SETTINGS_ID" : @"prefs:root=General&path=Network")];
+	[[FSSwitchPanel sharedPanel] openURLAsAlternateAction:url];
 }
 
 static DataSpeedSwitch *activeSwitch;
 
 static void FSDataStatusChanged(void)
 {
-  NSString *bundlePath = nil;
-  CFArrayRef supportedDataRates = CTRegistrationCopySupportedDataRates();
-  if (supportedDataRates) {
-    if ([(NSArray *)supportedDataRates containsObject:(id)kCTRegistrationDataRate3G]) {
-      if ([(NSArray *)supportedDataRates containsObject:(id)kCTRegistrationDataRate4G]) {
-        bundlePath = @"/Library/Switches/LTE.bundle";
-      } else {
-        bundlePath = @"/Library/Switches/3G.bundle";
-      }
-    }
-    CFRelease(supportedDataRates);
-  }
-  DataSpeedSwitch *oldActiveSwitch = activeSwitch;
-  if (!bundlePath && !oldActiveSwitch)
-    return;
-  if (bundlePath) {
-    if ([oldActiveSwitch.bundle.bundlePath isEqualToString:bundlePath]) {
-      [[FSSwitchPanel sharedPanel] stateDidChangeForSwitchIdentifier:oldActiveSwitch.bundle.bundleIdentifier];
-      return;
-    }
-    NSBundle *newBundle = [NSBundle bundleWithPath:bundlePath];
-    activeSwitch = [[DataSpeedSwitch alloc] initWithBundle:newBundle];
-    [[FSSwitchPanel sharedPanel] registerDataSource:activeSwitch forSwitchIdentifier:newBundle.bundleIdentifier];
-  } else {
-    activeSwitch = nil;
-  }
-  if (oldActiveSwitch) {
-    [[FSSwitchPanel sharedPanel] unregisterSwitchIdentifier:oldActiveSwitch.bundle.bundleIdentifier];
-    [oldActiveSwitch release];
-  }
+    NSString *bundlePath = nil;
+	CFArrayRef supportedDataRates = CTRegistrationCopySupportedDataRates();
+	if (supportedDataRates) {
+		if ([(NSArray *)supportedDataRates containsObject:(id)kCTRegistrationDataRate3G]) {
+			if ([(NSArray *)supportedDataRates containsObject:(id)kCTRegistrationDataRate4G]) {
+				bundlePath = @"/Library/Switches/LTE.bundle";
+			} else {
+				bundlePath = @"/Library/Switches/3G.bundle";
+			}
+		}
+		CFRelease(supportedDataRates);
+	}
+	DataSpeedSwitch *oldActiveSwitch = activeSwitch;
+	if (!bundlePath && !oldActiveSwitch)
+		return;
+	if (bundlePath) {
+		if ([oldActiveSwitch.bundle.bundlePath isEqualToString:bundlePath]) {
+			[[FSSwitchPanel sharedPanel] stateDidChangeForSwitchIdentifier:oldActiveSwitch.bundle.bundleIdentifier];
+			return;
+		}
+		NSBundle *newBundle = [NSBundle bundleWithPath:bundlePath];
+		activeSwitch = [[DataSpeedSwitch alloc] initWithBundle:newBundle];
+		[[FSSwitchPanel sharedPanel] registerDataSource:activeSwitch forSwitchIdentifier:newBundle.bundleIdentifier];
+	} else {
+		activeSwitch = nil;
+	}
+	if (oldActiveSwitch) {
+		[[FSSwitchPanel sharedPanel] unregisterSwitchIdentifier:oldActiveSwitch.bundle.bundleIdentifier];
+		[oldActiveSwitch release];
+	}
 }
 
 - (Class <FSSwitchSettingsViewController>)settingsViewControllerClassForSwitchIdentifier:(NSString *)switchIdentifier
 {
 	Class result = nil;
 	CFArrayRef supportedDataRates = CTRegistrationCopySupportedDataRates();
-  if (supportedDataRates) {
-    if ([(NSArray *)supportedDataRates containsObject:(id)kCTRegistrationDataRate4G]) {
+	if (supportedDataRates) {
+		if ([(NSArray *)supportedDataRates containsObject:(id)kCTRegistrationDataRate4G]) {
 				result = [DataSpeedSwitchSettingsViewController class];
-      }
-    CFRelease(supportedDataRates);
-  }
-  return result;
+			}
+		CFRelease(supportedDataRates);
+	}
+	return result;
 }
 
 - (CFStringRef)chosenDataRate:(Boolean)forON {
@@ -164,8 +164,8 @@ static void FSDataStatusChanged(void)
 	}
 
 	switch (value) {
-  	case 0:
-      return kCTRegistrationDataRate4G;
+		case 0:
+			return kCTRegistrationDataRate4G;
 		case 1:
 			return kCTRegistrationDataRate3G;
 		default:
@@ -195,7 +195,7 @@ static void FSDataStatusChanged(void)
 		value = CFPreferencesGetAppIntegerValue(CFSTR("offDataRate"), CFSTR("com.a3tweaks.switch.dataspeed"), &valid);
 		offDataRate = valid ? value : 1; // default to 3G
 	}
-  return self;
+	return self;
 }
 
 - (NSInteger)tableView:(UITableView *)table numberOfRowsInSection:(NSInteger)section
@@ -211,27 +211,27 @@ static void FSDataStatusChanged(void)
 - (NSString *)tableView:(UITableView *)table titleForHeaderInSection:(NSInteger)section
 {
 	switch (section) {
-    case 0:
-      return @"ON Data Rate";
-    case 1:
-      return @"OFF Data Rate";
-    default:
-      return nil;
+		case 0:
+			return @"ON Data Rate";
+		case 1:
+			return @"OFF Data Rate";
+		default:
+			return nil;
 	}
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell"] ?: [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"cell"] autorelease];
+	UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell"] ?: [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"cell"] autorelease];
 	cell.textLabel.text = [_supportedDataRates objectAtIndex:indexPath.row];
 	CFIndex value = indexPath.section ? offDataRate : onDataRate;
-  cell.accessoryType = (value == indexPath.row) ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
-  return cell;
+	cell.accessoryType = (value == indexPath.row) ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+	return cell;
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-  [tableView deselectRowAtIndexPath:indexPath animated:YES];
+	[tableView deselectRowAtIndexPath:indexPath animated:YES];
 
 	// ON must be > OFF
 	if (indexPath.section) {
@@ -241,13 +241,13 @@ static void FSDataStatusChanged(void)
 		if (indexPath.row >= offDataRate) return;
 	}
 
-  UITableViewCell *cell = [tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:(indexPath.section ? offDataRate : onDataRate) inSection:indexPath.section]];
+	UITableViewCell *cell = [tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:(indexPath.section ? offDataRate : onDataRate) inSection:indexPath.section]];
 	cell.accessoryType = UITableViewCellAccessoryNone;
 
 	cell = [tableView cellForRowAtIndexPath:indexPath];
 	CFStringRef key;
 	NSInteger value = indexPath.row;
-  cell.accessoryType = UITableViewCellAccessoryCheckmark;
+	cell.accessoryType = UITableViewCellAccessoryCheckmark;
 	if (indexPath.section) {
 		key = CFSTR("offDataRate");
 		offDataRate = value;
@@ -256,7 +256,7 @@ static void FSDataStatusChanged(void)
 		onDataRate = value;
 	}
 	CFPreferencesSetAppValue(key, (CFTypeRef)[NSNumber numberWithInteger:value], CFSTR("com.a3tweaks.switch.dataspeed"));
-  CFPreferencesAppSynchronize(CFSTR("com.a3tweaks.switch.dataspeed"));
+	CFPreferencesAppSynchronize(CFSTR("com.a3tweaks.switch.dataspeed"));
 }
 
 @end
@@ -264,14 +264,14 @@ static void FSDataStatusChanged(void)
 __attribute__((constructor))
 static void constructor(void)
 {
-  /*
-  crappy workaround on detecting whether or not to register the observer and the switch:
-  - if stacktrace includes SpringBoard, GO!
-  */
-  for (NSString *symbol in [NSThread callStackSymbols]) {
-    if ([symbol rangeOfString:@" SpringBoard " options:0].location != NSNotFound) {
-      CTTelephonyCenterAddObserver(CTTelephonyCenterGetDefault(), NULL, (CFNotificationCallback)FSDataStatusChanged, kCTRegistrationDataStatusChangedNotification, NULL, CFNotificationSuspensionBehaviorCoalesce);
-      FSDataStatusChanged();
-    };
-  };
+	/*
+	crappy workaround on detecting whether or not to register the observer and the switch:
+	- if stacktrace includes SpringBoard, GO!
+	*/
+	for (NSString *symbol in [NSThread callStackSymbols]) {
+		if ([symbol rangeOfString:@" SpringBoard " options:0].location != NSNotFound) {
+			CTTelephonyCenterAddObserver(CTTelephonyCenterGetDefault(), NULL, (CFNotificationCallback)FSDataStatusChanged, kCTRegistrationDataStatusChangedNotification, NULL, CFNotificationSuspensionBehaviorCoalesce);
+			FSDataStatusChanged();
+		};
+	};
 }

--- a/Switches/3G/Switch.x
+++ b/Switches/3G/Switch.x
@@ -20,10 +20,16 @@ void CTTelephonyCenterRemoveObserver(CFNotificationCenterRef center, const void 
 
 @interface DataSpeedSwitch : NSObject <FSSwitchDataSource> {
 @private
-	NSBundle *_bundle;
-	NSString *_desiredDataRate;
+  NSBundle *_bundle;
 }
 @property (nonatomic, readonly) NSBundle *bundle;
+@end
+
+@interface DataSpeedSwitchSettingsViewController : UITableViewController <FSSwitchSettingsViewController> {
+	NSArray *_supportedDataRates;
+	NSInteger offDataRate;
+	NSInteger onDataRate;
+}
 @end
 
 static void FSDataStatusChanged(void);
@@ -32,109 +38,225 @@ static void FSDataStatusChanged(void);
 
 - (id)init
 {
-	[self release];
-	return nil;
+  [self release];
+  return nil;
 }
 
-- (id)initWithBundle:(NSBundle *)bundle desiredDataRate:(NSString *)desiredDataRate
+- (id)initWithBundle:(NSBundle *)bundle
 {
-	if ((self = [super init])) {
-		_bundle = [bundle retain];
-		_desiredDataRate = [desiredDataRate copy];
-	}
+  if ((self = [super init])) {
+    _bundle = [bundle retain];
+  }
 
-	return self;
+  return self;
 }
 
 - (void)dealloc
 {
-	[_bundle release];
-	[_desiredDataRate release];
-	[super dealloc];
+  [_bundle release];
+  [super dealloc];
 }
 
 @synthesize bundle = _bundle;
 
 - (NSBundle *)bundleForSwitchIdentifier:(NSString *)switchIdentifier
 {
-	return _bundle;
+  return _bundle;
 }
 
 - (FSSwitchState)stateForSwitchIdentifier:(NSString *)switchIdentifier
 {
-	NSArray *supportedDataRates = [(NSArray *)CTRegistrationCopySupportedDataRates() autorelease];
-	NSUInteger desiredRateIndex = [supportedDataRates indexOfObject:_desiredDataRate];
-	if (desiredRateIndex == NSNotFound)
-		return FSSwitchStateOff;
-	NSUInteger currentRateIndex = [supportedDataRates indexOfObject:(id)CTRegistrationGetCurrentMaxAllowedDataRate()];
-	if (currentRateIndex == NSNotFound)
-		return FSSwitchStateOff;
-	return currentRateIndex >= desiredRateIndex;
+  NSArray *supportedDataRates = [(NSArray *)CTRegistrationCopySupportedDataRates() autorelease];
+  NSUInteger desiredRateIndex = [supportedDataRates indexOfObject:(id)[self chosenDataRate:YES]];
+  if (desiredRateIndex == NSNotFound)
+    return FSSwitchStateOff;
+  NSUInteger currentRateIndex = [supportedDataRates indexOfObject:(id)CTRegistrationGetCurrentMaxAllowedDataRate()];
+  if (currentRateIndex == NSNotFound)
+    return FSSwitchStateOff;
+  return currentRateIndex >= desiredRateIndex;
 }
 
 - (void)applyState:(FSSwitchState)newState forSwitchIdentifier:(NSString *)switchIdentifier
 {
-	if (newState == FSSwitchStateIndeterminate)
-		return;
-	NSArray *supportedDataRates = [(NSArray *)CTRegistrationCopySupportedDataRates() autorelease];
-	NSUInteger desiredRateIndex = [supportedDataRates indexOfObject:_desiredDataRate];
-	if (desiredRateIndex == NSNotFound)
-		return;
-	NSUInteger currentRateIndex = [supportedDataRates indexOfObject:(id)CTRegistrationGetCurrentMaxAllowedDataRate()];
-	if (currentRateIndex == NSNotFound)
-		return;
-	if (newState) {
-		if (currentRateIndex < desiredRateIndex)
-			CTRegistrationSetMaxAllowedDataRate((CFStringRef)_desiredDataRate);
-	} else {
-		if ((currentRateIndex >= desiredRateIndex) && desiredRateIndex)
-			CTRegistrationSetMaxAllowedDataRate((CFStringRef)[supportedDataRates objectAtIndex:desiredRateIndex - 1]);
-	}
+  if (newState == FSSwitchStateIndeterminate)
+    return;
+  NSArray *supportedDataRates = [(NSArray *)CTRegistrationCopySupportedDataRates() autorelease];
+  NSUInteger desiredRateIndex = [supportedDataRates indexOfObject:(id)[self chosenDataRate:YES]];
+  if (desiredRateIndex == NSNotFound)
+    return;
+  NSUInteger currentRateIndex = [supportedDataRates indexOfObject:(id)CTRegistrationGetCurrentMaxAllowedDataRate()];
+  if (currentRateIndex == NSNotFound)
+    return;
+  if (newState) {
+    if (currentRateIndex < desiredRateIndex)
+      CTRegistrationSetMaxAllowedDataRate([self chosenDataRate:YES]);
+  } else {
+    if ((currentRateIndex >= desiredRateIndex) && desiredRateIndex)
+      CTRegistrationSetMaxAllowedDataRate([self chosenDataRate:NO]);
+  }
 }
 
 - (void)applyAlternateActionForSwitchIdentifier:(NSString *)switchIdentifier
 {
-	NSURL *url = [NSURL URLWithString:(kCFCoreFoundationVersionNumber > 700.0f ? @"prefs:root=General&path=MOBILE_DATA_SETTINGS_ID" : @"prefs:root=General&path=Network")];
-	[[FSSwitchPanel sharedPanel] openURLAsAlternateAction:url];
+  NSURL *url = [NSURL URLWithString:(kCFCoreFoundationVersionNumber > 700.0f ? @"prefs:root=General&path=MOBILE_DATA_SETTINGS_ID" : @"prefs:root=General&path=Network")];
+  [[FSSwitchPanel sharedPanel] openURLAsAlternateAction:url];
 }
 
 static DataSpeedSwitch *activeSwitch;
 
 static void FSDataStatusChanged(void)
 {
-    NSString *bundlePath = nil;
-    NSString *desiredDataRate = nil;
+  NSString *bundlePath = nil;
+  CFArrayRef supportedDataRates = CTRegistrationCopySupportedDataRates();
+  if (supportedDataRates) {
+    if ([(NSArray *)supportedDataRates containsObject:(id)kCTRegistrationDataRate3G]) {
+      if ([(NSArray *)supportedDataRates containsObject:(id)kCTRegistrationDataRate4G]) {
+        bundlePath = @"/Library/Switches/LTE.bundle";
+      } else {
+        bundlePath = @"/Library/Switches/3G.bundle";
+      }
+    }
+    CFRelease(supportedDataRates);
+  }
+  DataSpeedSwitch *oldActiveSwitch = activeSwitch;
+  if (!bundlePath && !oldActiveSwitch)
+    return;
+  if (bundlePath) {
+    if ([oldActiveSwitch.bundle.bundlePath isEqualToString:bundlePath]) {
+      [[FSSwitchPanel sharedPanel] stateDidChangeForSwitchIdentifier:oldActiveSwitch.bundle.bundleIdentifier];
+      return;
+    }
+    NSBundle *newBundle = [NSBundle bundleWithPath:bundlePath];
+    activeSwitch = [[DataSpeedSwitch alloc] initWithBundle:newBundle];
+    [[FSSwitchPanel sharedPanel] registerDataSource:activeSwitch forSwitchIdentifier:newBundle.bundleIdentifier];
+  } else {
+    activeSwitch = nil;
+  }
+  if (oldActiveSwitch) {
+    [[FSSwitchPanel sharedPanel] unregisterSwitchIdentifier:oldActiveSwitch.bundle.bundleIdentifier];
+    [oldActiveSwitch release];
+  }
+}
+
+- (Class <FSSwitchSettingsViewController>)settingsViewControllerClassForSwitchIdentifier:(NSString *)switchIdentifier
+{
+	Class result = nil;
 	CFArrayRef supportedDataRates = CTRegistrationCopySupportedDataRates();
-	if (supportedDataRates) {
-		if ([(NSArray *)supportedDataRates containsObject:(id)kCTRegistrationDataRate3G]) {
-			if ([(NSArray *)supportedDataRates containsObject:(id)kCTRegistrationDataRate4G]) {
-				bundlePath = @"/Library/Switches/LTE.bundle";
-				desiredDataRate = (NSString *)kCTRegistrationDataRate4G;
-			} else {
-				bundlePath = @"/Library/Switches/3G.bundle";
-				desiredDataRate = (NSString *)kCTRegistrationDataRate3G;
-			}
+  if (supportedDataRates) {
+    if ([(NSArray *)supportedDataRates containsObject:(id)kCTRegistrationDataRate4G]) {
+				result = [DataSpeedSwitchSettingsViewController class];
+      }
+    CFRelease(supportedDataRates);
+  }
+  return result;
+}
+
+- (CFStringRef)chosenDataRate:(Boolean)forON {
+	CFStringRef key = forON ? CFSTR("onDataRate") : CFSTR("offDataRate");
+	Boolean valid;
+	CFIndex value = CFPreferencesGetAppIntegerValue(key, CFSTR("com.a3tweaks.switch.dataspeed"), &valid);
+
+	if (!valid) {
+		if ([self.bundle.bundlePath isEqualToString:@"/Library/Switches/LTE.bundle"]) {
+			return forON ? kCTRegistrationDataRate4G : kCTRegistrationDataRate3G;
 		}
-		CFRelease(supportedDataRates);
+		return forON ? kCTRegistrationDataRate3G : kCTRegistrationDataRate2G;
 	}
-	DataSpeedSwitch *oldActiveSwitch = activeSwitch;
-	if (!bundlePath && !oldActiveSwitch)
-		return;
-	if (bundlePath) {
-		if ([oldActiveSwitch.bundle.bundlePath isEqualToString:bundlePath]) {
-			[[FSSwitchPanel sharedPanel] stateDidChangeForSwitchIdentifier:oldActiveSwitch.bundle.bundleIdentifier];
-			return;
-		}
-		NSBundle *newBundle = [NSBundle bundleWithPath:bundlePath];
-		activeSwitch = [[DataSpeedSwitch alloc] initWithBundle:newBundle desiredDataRate:desiredDataRate];
-		[[FSSwitchPanel sharedPanel] registerDataSource:activeSwitch forSwitchIdentifier:newBundle.bundleIdentifier];
+
+	switch (value) {
+  	case 0:
+      return kCTRegistrationDataRate4G;
+		case 1:
+			return kCTRegistrationDataRate3G;
+		default:
+			return kCTRegistrationDataRate2G;
+ 	}
+}
+
+@end
+
+@implementation DataSpeedSwitchSettingsViewController
+
+- (id)init
+{
+	if ((self = [super initWithStyle:UITableViewStyleGrouped])) {
+		_supportedDataRates = [NSArray arrayWithObjects:
+ 			@"4G",
+ 			@"3G",
+			@"2G",
+			nil
+		];
+
+		Boolean valid;
+		// settings are stored in the normal (ascending) order
+		CFIndex value = CFPreferencesGetAppIntegerValue(CFSTR("onDataRate"), CFSTR("com.a3tweaks.switch.dataspeed"), &valid);
+		onDataRate = valid ? value : 0; // default to 4G, settings are only available if 4G is supported
+
+		value = CFPreferencesGetAppIntegerValue(CFSTR("offDataRate"), CFSTR("com.a3tweaks.switch.dataspeed"), &valid);
+		offDataRate = valid ? value : 1; // default to 3G
+	}
+  return self;
+}
+
+- (NSInteger)tableView:(UITableView *)table numberOfRowsInSection:(NSInteger)section
+{
+	return [_supportedDataRates count];
+}
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)table
+{
+	return 2;
+}
+
+- (NSString *)tableView:(UITableView *)table titleForHeaderInSection:(NSInteger)section
+{
+	switch (section) {
+    case 0:
+      return @"ON Data Rate";
+    case 1:
+      return @"OFF Data Rate";
+    default:
+      return nil;
+	}
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell"] ?: [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"cell"] autorelease];
+	cell.textLabel.text = [_supportedDataRates objectAtIndex:indexPath.row];
+	CFIndex value = indexPath.section ? offDataRate : onDataRate;
+  cell.accessoryType = (value == indexPath.row) ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+  return cell;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+  [tableView deselectRowAtIndexPath:indexPath animated:YES];
+
+	// ON must be > OFF
+	if (indexPath.section) {
+		if (indexPath.row <= onDataRate) return;
+	}
+	else {
+		if (indexPath.row >= offDataRate) return;
+	}
+
+  UITableViewCell *cell = [tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:(indexPath.section ? offDataRate : onDataRate) inSection:indexPath.section]];
+	cell.accessoryType = UITableViewCellAccessoryNone;
+
+	cell = [tableView cellForRowAtIndexPath:indexPath];
+	CFStringRef key;
+	NSInteger value = indexPath.row;
+  cell.accessoryType = UITableViewCellAccessoryCheckmark;
+	if (indexPath.section) {
+		key = CFSTR("offDataRate");
+		offDataRate = value;
 	} else {
-		activeSwitch = nil;
+		key = CFSTR("onDataRate");
+		onDataRate = value;
 	}
-	if (oldActiveSwitch) {
-		[[FSSwitchPanel sharedPanel] unregisterSwitchIdentifier:oldActiveSwitch.bundle.bundleIdentifier];
-		[oldActiveSwitch release];
-	}
+	CFPreferencesSetAppValue(key, (CFTypeRef)[NSNumber numberWithInteger:value], CFSTR("com.a3tweaks.switch.dataspeed"));
+  CFPreferencesAppSynchronize(CFSTR("com.a3tweaks.switch.dataspeed"));
 }
 
 @end
@@ -142,6 +264,14 @@ static void FSDataStatusChanged(void)
 __attribute__((constructor))
 static void constructor(void)
 {
-	CTTelephonyCenterAddObserver(CTTelephonyCenterGetDefault(), NULL, (CFNotificationCallback)FSDataStatusChanged, kCTRegistrationDataStatusChangedNotification, NULL, CFNotificationSuspensionBehaviorCoalesce);
-	FSDataStatusChanged();
+  /*
+  crappy workaround on detecting whether or not to register the observer and the switch:
+  - if stacktrace includes SpringBoard, GO!
+  */
+  for (NSString *symbol in [NSThread callStackSymbols]) {
+    if ([symbol rangeOfString:@" SpringBoard " options:0].location != NSNotFound) {
+      CTTelephonyCenterAddObserver(CTTelephonyCenterGetDefault(), NULL, (CFNotificationCallback)FSDataStatusChanged, kCTRegistrationDataStatusChangedNotification, NULL, CFNotificationSuspensionBehaviorCoalesce);
+      FSDataStatusChanged();
+    };
+  };
 }


### PR DESCRIPTION
FlipSwitch Settings view for 3G/LTE toggle so we can choose which is the rate for ON and which one for OFF.
Default is still the same as before:
- if LTE is supported, ON is 4G, if not, ON is 3G
- OFF is index of ON - 1

As the library constructor calls `FSDataStatusChanged()` an ugly-workaround was done to prevent registering the switch when called by the Settings panel, I'm open to comments on the proper way to do it in order to get such functionality pushed to the default toggle!