### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Flipswitch
+# Flipswitch
 
 Flipswitch is a library to implement a common infrastructure for On/Off switches. It provides a number of default switches to be used by tweaks such as Activator, Auxo and others, and may be extended through packages that add additional switches.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
